### PR TITLE
improve prompt input for yes

### DIFF
--- a/faereld/controller.py
+++ b/faereld/controller.py
@@ -138,8 +138,8 @@ class Controller(object):
             time_diff,
             purpose,
         )
-        confirmation = prompt("Is this correct? (y/n) :: ", vi_mode=True)
-        if confirmation.lower() == "y":
+        confirmation = prompt("Is this correct? (Y/n) :: ", vi_mode=True)
+        if confirmation in ["Y", "y", ""]:
             return {
                 "area": area,
                 "object": object,


### PR DESCRIPTION
At the end of the user flow to complete an entry, faereld will ask:

```
Is this correct? (y/n) ::
```

This will require the user to press "y" and "y" only to accept the
input. This pull-request changes the display (and behaviour) to:

```
Is this correct? (Y/n) ::
```

I.e. uppercase "Y" is displayed. This is a common convention in many
command line tools to present user input like this to indicate what the
default value will be. In this case, if user simply presses enter the
data will be accepted and added to the database. This will save a
keystroke everytime a user inputs data to faereld. The characters "Y" and
"y" are also acceptable inputs to accept the data.