### PR TITLE
Fix date output for non wendings date

### DIFF
--- a/faereld/controller.py
+++ b/faereld/controller.py
@@ -119,7 +119,7 @@ class Controller(object):
         from_date, to_date = self.input_duration()
         time_diff = utils.time_diff(from_date, to_date)
         print()
-        if self.config.get_use_wending:
+        if self.config.get_use_wending():
             date_display = from_date.strftime("{daeg} {month} {gere}")
         else:
             date_display = from_date.strftime("%d %b %Y")


### PR DESCRIPTION
During input collection, there was a bug when using non wending date.
Here is what it looked like:

```
On {daeg} {month} {gere} I worked on Numba (Research) for 1h16m - Reading about SSA, dominance frontiers and phi-nodes
Is this correct? (Y/n) ::
```

And here is what it looks like after the fix:

```
On 05 Apr 2019 I worked on Færeld (Debug) for 0h3m - fix faereld date output
Is this correct? (Y/n) ::
```