### PR TITLE
WIP: allow for hour.minute entries only

### DIFF
--- a/faereld/controller.py
+++ b/faereld/controller.py
@@ -271,7 +271,13 @@ class Controller(object):
             if date_string.lower() == "now":
                 now = datetime.datetime.now().replace(second=0)
                 return now
-
+            elif "//" not in date_string:
+                parsed = datetime.datetime.strptime(date_string, "%H.%M")
+                return datetime.datetime.today().replace(
+                    hour=parsed.hour,
+                    minute=parsed.minute,
+                    second=0,
+                )
             else:
                 return datetime.datetime.strptime(date_string, "%d %b %Y // %H.%M")
 
@@ -279,6 +285,6 @@ class Controller(object):
             print()
             print(
                 "{} is an invalid date string. For example, it must be of"
-                " the form: 3 Dec 2018 // 16.15".format(date_string)
+                " the form: '3 Dec 2018 // 16.15' or just '16.15'".format(date_string)
             )
             return None

--- a/faereld/controller.py
+++ b/faereld/controller.py
@@ -274,9 +274,7 @@ class Controller(object):
             elif "//" not in date_string:
                 parsed = datetime.datetime.strptime(date_string, "%H.%M")
                 return datetime.datetime.today().replace(
-                    hour=parsed.hour,
-                    minute=parsed.minute,
-                    second=0,
+                    hour=parsed.hour, minute=parsed.minute, second=0
                 )
             else:
                 return datetime.datetime.strptime(date_string, "%d %b %Y // %H.%M")


### PR DESCRIPTION
I often find myself just wanting to enter a time with today's date. For
example, If I forgot to start Færeld at the beginning of the task. In
that case, I usually want to do the entry before leaving the computer
for the day. In such cases I would just like to enter two time
specifications.

This only implements this feature for Gregorian calendar. If the
implementation is deemed appropriate I will port it to Wendings.