### PR TITLE
zero pad displayed time_delta

### DIFF
--- a/faereld/utils.py
+++ b/faereld/utils.py
@@ -24,7 +24,7 @@ def time_diff(from_date, to_date):
 def format_time_delta(time_delta):
     hours, remainder = divmod(time_delta.total_seconds(), 3600)
     minutes = floor(remainder / 60)
-    return f"{floor(hours)}h{minutes}m"
+    return f"{floor(hours)}h{minutes:02}m"
 
 
 def get_rendered_string(


### PR DESCRIPTION
This will display like `1h00m` rather than `1h0m` and makes the length
of the duration predictable. This is useful for making summaries like:

```
17 Apr 2020 :: 17:30 - 18:00 (0h30m) :: Færeld (Development) - Tweak summary output
17 Apr 2020 :: 15:00 - 17:30 (2h30m) :: Numba (Debug) - Debug Datashader integration tests and extract reproducer
17 Apr 2020 :: 13:00 - 15:00 (2h00m) :: Numba (Development) - teaxsbbq test and ci config
17 Apr 2020 :: 10:00 - 12:00 (2h00m) :: Numba (Development) - texasbbq test and ci config
```