### PR TITLE
adding start and end to rendering string

### DIFF
--- a/faereld/controller.py
+++ b/faereld/controller.py
@@ -63,6 +63,8 @@ class Entry:
             date_display,
             self.config.get_object_name(self.area, self.object),
             duration,
+            self.from_date,
+            self.to_date,
             self.purpose,
         )
         return "".join(str(s) for s in rendered_string)

--- a/faereld/summaries/detailed.py
+++ b/faereld/summaries/detailed.py
@@ -72,6 +72,8 @@ class DetailedSummary(object):
                     start_date,
                     self.config.get_object_name(entry.area, entry.obj),
                     utils.time_diff(entry.start, entry.end),
+                    entry.start,
+                    entry.end,
                     entry.purpose,
                 )
             )

--- a/faereld/utils.py
+++ b/faereld/utils.py
@@ -28,7 +28,8 @@ def format_time_delta(time_delta):
 
 
 def get_rendered_string(
-    area_code, area, date_to_display, object_name, duration, purpose
+    area_code, area, date_to_display, object_name, duration, start, end,
+    purpose
 ):
     fields = {
         "area": area_code,
@@ -36,6 +37,8 @@ def get_rendered_string(
         "object": object_name,
         "date": date_to_display,
         "duration": duration,
+        "start": start.strftime("%H:%M"),
+        "end": end.strftime("%H:%M"),
         "purpose": purpose,
     }
     elements = []

--- a/seonu/usage/configuration.rst
+++ b/seonu/usage/configuration.rst
@@ -84,6 +84,8 @@ The valid substitution options for a project area's rendering string are:
 - ``{object}`` :: The name of the object of the entry (e.g. Project A)
 - ``{date}`` :: The date of the start date of the entry (e.g. 02 Jan 2017)
 - ``{duration}`` :: The duration of the entry (e.g. 30m)
+- ``{start}`` :: The start time of the entry (e.g. 18:00)
+- ``{end}`` :: The end time of the entry (e.g. 23:42)
 
 Projects
 --------
@@ -151,6 +153,9 @@ The valid substitution options for a project area's rendering string are:
 - ``{object}`` :: The name of the object of the entry (e.g. Book A)
 - ``{date}`` :: The date of the start date of the entry (e.g. 02 Jan 2017)
 - ``{duration}`` :: The duration of the entry (e.g. 30m)
+- ``{start}`` :: The start time of the entry (e.g. 18:00)
+- ``{end}`` :: The end time of the entry (e.g. 23:42)
+
 
 The ``use_last_objects`` option defines that, upon insertion of that area,
 whether the last x objects (x being the defined value in


### PR DESCRIPTION
This allows `{start}` and `{end}` to be used as fields when rendering a
description string.

I noticed that `purpose` also seems undocumented.